### PR TITLE
Fix empty navigation menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,1 +1,13 @@
 main:
+  - title: "Home"
+    url: "/"
+  - title: "About"
+    url: "/#about"
+  - title: "Experience"
+    url: "/#experience"
+  - title: "Projects"
+    url: "/#projects"
+  - title: "Education"
+    url: "/#education"
+  - title: "Contact"
+    url: "/#contact"


### PR DESCRIPTION
## Summary
- populate `_data/navigation.yml` with the site's menu links

The theme uses `_data/navigation.yml` to build the main navigation. This file only contained `main:` which caused the navigation bar to be empty. Filling it with the links defined in `_config.yml` restores the navigation.

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_685418917b28833285888bb685e36acc