### PR TITLE
Add htmlproofer and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
+      - name: Build site
+        run: bundle exec jekyll build
+      - name: Run HTML Proofer
+        run: bundle exec htmlproofer ./_site

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 3.7"
-gem "minimal-mistakes-jekyll"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
@@ -12,4 +11,6 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-algolia"
+  gem "html-proofer"
+  gem "kramdown-parser-gfm"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ github_username: Ilona-a-k
 
 # Build settings
 markdown: kramdown
-#theme: minima
+remote_theme: "mmistakes/minimal-mistakes@4.24.0"
 
 author:
   name             : "Ilona Kalinina"


### PR DESCRIPTION
## Summary
- include `html-proofer` gem for link checking
- fix Jekyll dependencies and set theme
- validate site automatically with a GitHub Actions workflow
- switch to the Minimal Mistakes remote theme so GitHub Actions can find it

## Testing
- `bundle install --jobs 4 --retry 3` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle exec htmlproofer ./_site` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6854197f68a0833290a4658371bae8ff